### PR TITLE
Fixed FFmpeg url

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ lowfi open
 
 ## Prerequisites
 
-- [**ffmpeg**](https://ffmpge.org): Converting audio formats.
+- [**ffmpeg**](https://ffmpeg.org): Converting audio formats.
 - [**node-gyp**](https://npmjs.com/package/node-gyp): Compiling native addon modules.
 
 ## Contributing


### PR DESCRIPTION
There was mispelled url, which routes to ffmpge.org instead of ffmpeg.org.

My first PR, hope it helps. 😅